### PR TITLE
Changed 'Format' icon

### DIFF
--- a/resources/config/redactor.php
+++ b/resources/config/redactor.php
@@ -3,7 +3,7 @@
 return [
     'buttons'        => [
         'format'         => [
-            'icon' => 'fa fa-paragraph',
+            'icon' => 'fa fa-font',
         ],
         'bold'           => [
             'icon' => 'fa fa-bold',


### PR DESCRIPTION
Previously the paragraph icon was used, but I find the font icon clearer to the user.

I was looking for the format feature but kept looking over it, because i thought the button would just start a 'new paragraph'.

Before:
![Screenshot 1](https://www.evernote.com/l/AAZsb04gTiRIY6uc2FdygrFW0LVZZRA6k-0B/image.png)

After:
![Screenshot 2](https://www.evernote.com/l/AAbZxOyRIwJIZbRH1y51rZv9A_s9U15Ma84B/image.png)
