### PR TITLE
Making work in subfolder installations

### DIFF
--- a/resources/js/plugins/filemanager.js
+++ b/resources/js/plugins/filemanager.js
@@ -66,7 +66,7 @@
                     return false;
                 }
 
-                var url = '/files/download/' + $(e.target).data('entry');
+                var url = REQUEST_ROOT_PATH + '/files/download/' + $(e.target).data('entry');
 
                 this.insert.node($('<a />').attr('href', url).text(this.selection.is() ? this.selection.text() : url));
 

--- a/resources/js/plugins/filemanager.js
+++ b/resources/js/plugins/filemanager.js
@@ -35,7 +35,7 @@
                 $('#' + this.opts.element.attr('name') + '-modal')
                     .modal('show')
                     .find('.modal-content')
-                    .load('/streams/wysiwyg-field_type/index?' + params);
+                    .load(REQUEST_ROOT_PATH + '/streams/wysiwyg-field_type/index?' + params);
             },
             upload: function() {
 
@@ -46,7 +46,7 @@
                 $('#' + this.opts.element.attr('name') + '-modal')
                     .modal('show')
                     .find('.modal-content')
-                    .load('/streams/wysiwyg-field_type/choose?' + params);
+                    .load(REQUEST_ROOT_PATH + '/streams/wysiwyg-field_type/choose?' + params);
             },
             insert: function(e) {
 

--- a/resources/js/plugins/imagemanager.js
+++ b/resources/js/plugins/imagemanager.js
@@ -35,7 +35,7 @@
                 $('#' + this.opts.element.attr('name') + '-modal')
                     .modal('show')
                     .find('.modal-content')
-                    .load('/streams/wysiwyg-field_type/index?' + params);
+                    .load(REQUEST_ROOT_PATH + '/streams/wysiwyg-field_type/index?' + params);
             },
             upload: function() {
 
@@ -46,7 +46,7 @@
                 $('#' + this.opts.element.attr('name') + '-modal')
                     .modal('show')
                     .find('.modal-content')
-                    .load('/streams/wysiwyg-field_type/choose?' + params);
+                    .load(REQUEST_ROOT_PATH + '/streams/wysiwyg-field_type/choose?' + params);
             },
             insert: function(e) {
 
@@ -66,7 +66,7 @@
                     return false;
                 }
 
-                var url = '/files/' + file;
+                var url = REQUEST_ROOT_PATH + '/files/' + file;
 
                 this.insert.node($('<img />').attr('src', url));
 

--- a/resources/js/upload.js
+++ b/resources/js/upload.js
@@ -11,7 +11,7 @@ $(function() {
 
     var dropzone = new Dropzone('.dropzone', {
         paramName: 'upload',
-        url: '/streams/wysiwyg-field_type/handle',
+        url: REQUEST_ROOT_PATH + '/streams/wysiwyg-field_type/handle',
         headers: {
             'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
         },
@@ -74,7 +74,7 @@ $(function() {
 
         uploader.find('.uploaded .modal-body').html(element.data('loading') + '...');
 
-        uploader.find('.uploaded').load('/streams/wysiwyg-field_type/recent?' + $.param({
+        uploader.find('.uploaded').load(REQUEST_ROOT_PATH + '/streams/wysiwyg-field_type/recent?' + $.param({
             mode: element.data('mode'),
             uploaded: uploaded.join(',')
         }));


### PR DESCRIPTION
Image and file modals were 404ing on subfolder installations of Pyro, so added `REQUEST_ROOT_PATH` to request paths in a few places.